### PR TITLE
Updating backfill date

### DIFF
--- a/Constants.js
+++ b/Constants.js
@@ -2,7 +2,7 @@
 const DEBUG = false;
 const BACKFILL = '';
 // use format YYYY/MM/DD
-const BACKFILL_FROM = '2025/04/12';
+const BACKFILL_FROM = '';
 
 const CHAT_ID = DEBUG ? PERSONAL_CHAT_ID : GROUP_CHAT_ID; // Use Rishik's chat ID for debugging
 const BOT_UPDATE_URL = `https://api.telegram.org/bot${BOT_TOKEN}/getUpdates`;


### PR DESCRIPTION
Removed the hardcoded backfill date ('2025/04/12') from the BACKFILL_FROM constant
Rationale :
This change removes a static past date that was set in the BACKFILL_FROM constant. With this change, the Gmail search query will default to using the MAILS_LOOKBACK_PERIOD parameter (typically '1h' in production) instead of searching for emails after a specific date.
This prevents potential issues with using a fixed past date and allows the system to operate with its intended behaviour of only processing recent emails within the configured look back period.